### PR TITLE
Issue7 add kp forecast

### DIFF
--- a/chart.js
+++ b/chart.js
@@ -1334,7 +1334,7 @@
         var predKpSeries = {name: "Predicted Kp", data: [], type: "line",  boostThreshold : 50,turboThreshold: 1};
         var obsKpSeries = {name: "Observed Kp", data: [], type: "line",  boostThreshold : 50,turboThreshold: 1};
         var currentTime = new Date();
-        currentTime.setHours(currentTime.getHours() + 4);
+        currentTime.setHours(currentTime.getHours() + 24);
 
         $.each(data,function (i, value){
             var time = Date.parse(value[0] +'Z');
@@ -1349,6 +1349,7 @@
            	}
         });
         predKpSeries.data.unshift(obsKpSeries.data[obsKpSeries.data.length-1]);
+        obsKpSeries.data.push(predKpSeries[0]);
         series.push(predKpSeries);
         series.push(obsKpSeries);
 

--- a/chart.js
+++ b/chart.js
@@ -63,7 +63,7 @@
                 }else if(this.rangeSelector.selected == 3){
                     time_range = "7 Days";
                 }
-                this.setTitle({text: "Geospace Timeline: Lastest "+ time_range + " <br/> <span style='font-size: 12px;'>Solar Wind Predicted at Earth</span>"});
+                this.setTitle({text: "Geospace Timeline: Latest "+ time_range + " <br/> <span style='font-size: 12px;'>Solar Wind Predicted at Earth</span>"});
                 }
             }
           },
@@ -179,7 +179,7 @@
 
 
             title: {
-                text: '<span>Geospace Timeline: Lastest 24 Hours</span>',
+                text: "Geospace Timeline: Latest 7 Days <br/> <span style='font-size: 12px;'>Solar Wind Predicted at Earth</span>",
                 style: {"color": "#ffffff", "font-size": "16px", "margin-bottom": "25"},
                 align: 'left',
                 useHTML: true,
@@ -660,7 +660,7 @@
                 }else if(this.rangeSelector.selected == 3){
                     time_range = "7 Days";
                 }
-                this.setTitle({text: "Geospace Timeline: Lastest "+ time_range + " <br/> <span style='font-size: 12px;'>Solar Wind Predicted at Earth</span>"});
+                this.setTitle({text: "Geospace Prediction: Latest "+ time_range + " <br/> <span style='font-size: 12px;'>Model Output and Ground Truth Data</span>"});
                 }
             }
           },
@@ -774,7 +774,7 @@
 
 
             title: {
-                text: '<span> Geospace Model Predicted Kp and Dst (Ground Truth Data: SWPC Kp and Kyoto quick-look Dst) </span>',
+                text: "Geospace Prediction: Latest 7 Days <br/> <span style='font-size: 12px;'> Model Output and Ground Truth Data</span>",
                 style: {"color": "#ffffff", "font-size": "16px", "margin-bottom": "25"},
                 align: 'left',
                 useHTML: true,

--- a/chart.js
+++ b/chart.js
@@ -1068,7 +1068,7 @@
                     },
                     title: {
 						useHTML: true,
-                        text: '<center><font color="#4ac3c9">SWPC Kp</font><br/><font color="#21f26e">Geospace Kp</font></center><br/>',
+                        text: '<center><font color="#4ac3c9">Observed / </font><font color="#c1f1f2">Predicted Kp</font><br/><font color="#21f26e">Geospace Kp</font></center><br/>',
                         style: {'color': '#21f26e'}//,
                         //offset: 50
                     },
@@ -1239,7 +1239,7 @@
                     data: predKp.data,
                     yAxis: 1,
                     lineWidth: 1,
-                    color: 'red',
+                    color: '#c1f1f2',
                     tooltip: {
                         valueSuffix: "W"
                     },
@@ -1297,7 +1297,7 @@
         $.getJSON('https://services.swpc.noaa.gov/products/geospace/propagated-solar-wind.json', function (data) {
         var bzSeries = {name: "Bz", data: [], type: "line",  boostThreshold : 50,turboThreshold: 1}; 
         var btSeries = {name: "Bt", data: [], type: "line", boostThreshold : 50,turboThreshold: 1}; 
-        var tempSeries = {name: "Temperature", data: [], type: "line", boostThreshold : 50, turboThreshold: 1};
+        var tempSeries = {name: "Temp", data: [], type: "line", boostThreshold : 50, turboThreshold: 1};
         var densitySeries = {name: "Density", data: [], type: "line", boostThreshold : 50,turboThreshold: 1}; 
         var speedSeries = {name: "Speed", data: [], type: "line", boostThreshold : 50, turboThreshold: 1};  
 
@@ -1387,7 +1387,7 @@
             validTime = gdstSeries.data[gdstSeries.data.length-1][0];
 
                 $.getJSON('https://services.swpc.noaa.gov/experimental/products/kyoto-dst.json', function(data){
-                var kdstSeries = {name: "Kyoto DST", data: [], type: "line", boostThreshold : 50};
+                var kdstSeries = {name: "Kyoto Dst", data: [], type: "line", boostThreshold : 50};
                 $.each(data,function (i, value){
                     // Add X, Y values
                     if(i > 0){

--- a/chart.js
+++ b/chart.js
@@ -220,14 +220,14 @@
             }, 
 
             xAxis: [
-                //0 Current Time Line - vertical one
+                //0 Current Time Line - horizontal one on the x Axis
                 {   
                     top: '100%',
                     height: '0%',
                     plotLines: [{
                         value:  new Date(), //currentTime,
                         width: 1,
-                        color: '#2aadf9',
+                        color: '#2aadf9',  //blue current time vertical line
                         label: {
                             text: 'Latest value',
                             align: 'right',
@@ -262,7 +262,7 @@
                     tickPosition: 'outside',
                     minorGridLineWidth: 0,
                     minorTickInterval: 'auto',
-                    minorTickColor: '#ffffff',
+                    minorTickColor: '#ccd6eb',
                     minorTickLength: 0,
                     minorTickWidth: 0,
                     startOnTick: true,
@@ -283,7 +283,7 @@
                     tickPosition: 'inside',
                     minorGridLineWidth: 0,
                     minorTickInterval: 'auto',
-                    minorTickColor: '#ffffff',
+                    minorTickColor: '#ccd6eb',
                     minorTickLength: 3,
                     minorTickWidth: 1,
                     startOnTick: true,
@@ -304,7 +304,7 @@
                     tickPosition: 'outside',
                     minorGridLineWidth: 0,
                     minorTickInterval: 'auto',
-                    minorTickColor: '#ffffff',
+                    minorTickColor: '#ccd6eb',
                     minorTickLength: 0,
                     minorTickWidth: 1,
                     startOnTick: true,
@@ -325,7 +325,7 @@
                     tickPosition: 'inside',
                     minorGridLineWidth: 0,
                     minorTickInterval: 'auto',
-                    minorTickColor: '#ffffff',
+                    minorTickColor: '#ccd6eb',
                     minorTickLength: 3,
                     minorTickWidth: 1,
                     startOnTick: true,
@@ -346,7 +346,7 @@
                     tickPosition: 'outside',
                     minorGridLineWidth: 0,
                     minorTickInterval: 'auto',
-                    minorTickColor: '#ffffff',
+                    minorTickColor: '#ccd6eb',
                     minorTickLength: 0,
                     minorTickWidth: 1,
                     startOnTick: true,
@@ -367,12 +367,12 @@
                     tickPosition: 'inside',
                     minorGridLineWidth: 0,
                     minorTickInterval: 'auto',
-                    minorTickColor: '#ffffff',
+                    minorTickColor: '#ccd6eb',
                     minorTickLength: 3,
                     minorTickWidth: 1,
                     minorTickPosition: 'inside',
                     startOnTick: true,
-                    endOnTick: true,
+                    endOnTick: false,
                     labels: {
                         enabled: false
                     }
@@ -385,15 +385,15 @@
                     linkedTo: 0,
                     tickLength: 0,
                     tickWidth: 1,
-                    tickPosition: 'outside',
+                    tickPosition: 'inside',
                     minorGridLineWidth: 0,
                     minorTickInterval: 'auto',
-                    minorTickColor: '#ffffff',
+                    minorTickColor: '#ccd6eb',
                     minorTickLength: 0,
                     minorTickWidth: 1,
                     startOnTick: true,
-                    endOnTick: true,
-                    minorTickPosition: 'outside',
+                    endOnTick: false,
+                    minorTickPosition: 'inside',
                     labels: {
                         enabled: false
                     }     
@@ -409,7 +409,7 @@
                     tickPosition: 'inside',
                     minorGridLineWidth: 0,
                     minorTickInterval: 'auto',
-                    minorTickColor: '#ffffff',
+                    minorTickColor: '#ccd6eb',
                     minorTickLength: 3,
                     minorTickWidth: 1,
                     minorTickPosition: 'inside',
@@ -443,7 +443,7 @@
                     lineWidth: 1,
                     tickAmount: 5,
                     tickInterval: 1,
-                    tickColor: '#ffffff',
+                    tickColor: '#ccd6eb',
                     tickWidth: 1,
                     tickLength: 5,
                     tickPosition: 'inside',
@@ -473,11 +473,12 @@
                     gridLineColor: '#1A1818',
                     tickAmount: 5,
                     tickInterval: 1,
-                    tickColor: '#ffffff',
+                    tickColor: '#ccd6eb',
                     tickWidth: 1,
                     tickLength: 5,
                     tickPosition: 'inside'            
                 }, 
+
                 
 				//Y Axis 2
                 {
@@ -497,10 +498,10 @@
                     offset: 0,
                     lineWidth: 1,
                     gridLineColor: '#111111',
-                    lineColor: '#ffffff',
+                    lineColor: '#ccd6eb',
                     tickAmount: 5,
                     tickInterval: 10,
-                    tickColor: '#ffffff',
+                    tickColor: '#ccd6eb',
                     tickWidth: 1,
                     tickLength: 5,
                     tickPosition: 'inside'
@@ -536,14 +537,29 @@
                     offset: 0,
                     lineWidth: 1,
                     gridLineColor: '#111111',
-                    lineColor: '#ffffff',
+                    lineColor: '#ccd6eb',
                     tickAmount: 5,
                     tickInterval: 1,
-                    tickColor: '#ffffff',
+                    tickColor: '#ccd6eb',
                     tickWidth: 1,
                     tickLength: 5,
                     tickPosition: 'inside'
 
+                },
+
+                //Y Axis 3 - right side
+                {
+                    opposite: true,
+                    top: '78%',
+                    height: '22%',
+                    offset: 0,
+                    lineWidth: 1,
+                    lineColor: '#ccd6eb',
+                    tickAmount: 0,
+                  	gridLineColor: '#000000',
+                    labels: {
+                        enabled: false
+                    }     
                 },
              
             ], 

--- a/chart.js
+++ b/chart.js
@@ -265,8 +265,8 @@
                     minorTickColor: '#ccd6eb',
                     minorTickLength: 0,
                     minorTickWidth: 0,
-                    startOnTick: true,
-                    endOnTick: true,
+                    //startOnTick: true,
+                    //endOnTick: true,
                     minorTickPosition: 'outside',
                     labels: {
                         enabled: false
@@ -286,8 +286,8 @@
                     minorTickColor: '#ccd6eb',
                     minorTickLength: 3,
                     minorTickWidth: 1,
-                    startOnTick: true,
-                    endOnTick: true,
+                    //startOnTick: true,
+                    //endOnTick: true,
                     minorTickPosition: 'inside',
                     labels: {
                         enabled: false
@@ -544,9 +544,50 @@
                     tickWidth: 1,
                     tickLength: 5,
                     tickPosition: 'inside'
-
                 },
 
+                //Y Axis 0 - right side
+                {
+                    opposite: true,
+                    top: '0%',
+                    height: '24%',
+                    offset: 0,
+                    lineWidth: 1,
+                    lineColor: '#ccd6eb',
+                    tickAmount: 0,
+                  	gridLineColor: '#000000',
+                    labels: {
+                        enabled: false
+                    }  
+                },   
+                //Y Axis 1 - right side
+                {
+                    opposite: true,
+                    top: '26%',
+                    height: '24%',
+                    offset: 0,
+                    lineWidth: 1,
+                    lineColor: '#ccd6eb',
+                    tickAmount: 0,
+                  	gridLineColor: '#000000',
+                    labels: {
+                        enabled: false
+                    } 
+                },
+                //Y Axis 2 - right side
+                {
+                    opposite: true,
+                    top: '52%',
+                    height: '24%',
+                    offset: 0,
+                    lineWidth: 1,
+                    lineColor: '#ccd6eb',
+                    tickAmount: 0,
+                  	gridLineColor: '#000000',
+                    labels: {
+                        enabled: false
+                    }     
+                },
                 //Y Axis 3 - right side
                 {
                     opposite: true,
@@ -560,7 +601,7 @@
                     labels: {
                         enabled: false
                     }     
-                },
+                }
              
             ], 
 
@@ -1010,7 +1051,7 @@
                     gridLineColor: '#111111',
                     tickAmount: 5,
                     tickInterval: 15,
-                    tickColor: '#ffffff',
+                    tickColor: '#ccd6eb',
                     tickWidth: 1,
                     tickLength: 5,
                     tickPosition: 'inside'
@@ -1037,10 +1078,10 @@
                     min: 0,
                     max: 9,
                     gridLineColor: '#111111',
-                    lineColor: '#ffffff',
+                    lineColor: '#ccd6eb',
                     tickAmount: 11,
                     tickInterval: 1,
-                    tickColor: '#ffffff',
+                    tickColor: '#ccd6eb',
                     tickWidth: 1,
                     tickLength: 5,
                     tickPosition: 'inside'
@@ -1065,11 +1106,54 @@
                     lineWidth: 1,
                     gridLineColor: '#111111',
                     tickAmount: 5,
-                    tickColor: '#ffffff',
+                    tickColor: '#ccd6eb',
                     tickWidth: 1,
                     tickLength: 5,
                     tickPosition: 'inside'
                 },
+
+                //Y Axis 4 - right side
+                {
+                    opposite: true,
+                    top: '0%',
+                    height: '32%',
+                    offset: 0,
+                    lineWidth: 1,
+                    lineColor: '#ccd6eb',
+                    tickAmount: 0,
+                  	gridLineColor: '#000000',
+                    labels: {
+                        enabled: false
+                    }  
+                },   
+                //Y Axis 5 - right side
+                {
+                    opposite: true,
+                    top: '34%',
+                    height: '32%',
+                    offset: 0,
+                    lineWidth: 1,
+                    lineColor: '#ccd6eb',
+                    tickAmount: 0,
+                  	gridLineColor: '#000000',
+                    labels: {
+                        enabled: false
+                    } 
+                },
+                //Y Axis 6 - right side
+                {
+                    opposite: true,
+                    top: '68%',
+                    height: '32%',
+                    offset: 0,
+                    lineWidth: 1,
+                    lineColor: '#ccd6eb',
+                    tickAmount: 0,
+                  	gridLineColor: '#000000',
+                    labels: {
+                        enabled: false
+                    }     
+                }
             ], 
 
             series: [


### PR DESCRIPTION
With Kiley's help, I can now plot the forecasted Kp! 
Here are things that changed with this branch:
- Added the white lines to the right side of the plots
- Fixed the plot titles and typos
- Changed the line colors for the plot boxes and grid marks to the default off-white blue color
- Now read in from a JSON that has both the observed and forecasted Kp
- Plot the forecasted Kp in a different color
- Updated the y axis title to reflect the observed and forecasted Kp